### PR TITLE
Option to rename all processed attachments

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -115,6 +115,11 @@ function Gmail2GDrive() {
             var file = folder.createFile(attachment);
             if (rule.filenameFrom && rule.filenameTo && rule.filenameFrom == file.getName()) {
               var newFilename = Utilities.formatDate(messageDate, config.timezone, rule.filenameTo.replace('%s',message.getSubject()));
+              Logger.log("INFO:           Renaming matched file '" + file.getName() + "' -> '" + newFilename + "'");
+              file.setName(newFilename);
+            }
+            else if (rule.filenameTo) {
+              var newFilename = Utilities.formatDate(messageDate, config.timezone, rule.filenameTo.replace('%s',message.getSubject()));
               Logger.log("INFO:           Renaming '" + file.getName() + "' -> '" + newFilename + "'");
               file.setName(newFilename);
             }

--- a/Config.gs
+++ b/Config.gs
@@ -25,7 +25,8 @@ function getGmail2GDriveConfig() {
       //  * folder (String, mandatory): a path to an existing Google Drive folder (will be created, if not existing)
       //  * archive (boolean, optional): Should the gmail thread be archived after processing? (default: false)
       //  * filenameFrom (String, optional): The attachment filename that should be renamed when stored in Google Drive
-      //  * filenameTo (String, optional): The pattern for the new filename of the attachment. You can use '%s' to insert the email subject and date format patterns like 'yyyy' for year, 'MM' for month and 'dd' for day as pattern in the filename.
+      //  * filenameTo (String, optional): The pattern for the new filename of the attachment. If 'filenameFrom' is not given then this will be the new filename for all attachments.
+      //  * You can use '%s' to insert the email subject and date format patterns like 'yyyy' for year, 'MM' for month and 'dd' for day as pattern in the filename.
       //    See https://developers.google.com/apps-script/reference/utilities/utilities#formatDate(Date,String,String) for more information on the possible date format strings.
 
       { 
@@ -42,7 +43,13 @@ function getGmail2GDriveConfig() {
       },
       { 
       },
-      {
+      { // Replace all files with the variable 'filenameTo' string.
+        "filter": "(from:example3a@example.com OR from:example3b@example.com)",
+        "folder": "Examples/example3ab",
+        "filenameTo": "'file-'yyyy-MM-dd-'%s.txt'",
+        "archive": true
+      },
+      { // Replace all files that match the 'filenameFrom' string with the variable 'filenameTo' string
         "filter": "(from:example3a@example.com OR from:example3b@example.com)",
         "folder": "Examples/example3ab",
         "filenameFrom": "file.txt",


### PR DESCRIPTION
Currently the renaming functionality can only be used if filenameFrom is specified. However this limits what attachment file names can possibly be renamed. Instead, this pull would, in the case that filenameFrom was omitted but filenameTo was specified, make the program rename all attachments in the same way it currently does.