### PR TITLE
add placeholder for file name and some code restructuring (branch: Fileplaceholder)

### DIFF
--- a/Config.gs
+++ b/Config.gs
@@ -36,7 +36,7 @@ function getGmail2GDriveConfig() {
         // defined in 'filenameTo' and archive the thread.
         "filter": "has:attachment (from:example3a@example.com OR from:example3b@example.com)",
         "folder": "'Examples/example3ab'",
-        "filenameTo": "'file-'yyyy-MM-dd-'%s.txt'",
+        "filenameTo": "'file-'yyyy-MM-dd-'#FILE#'",
         "archive": true
       },
       {
@@ -51,7 +51,7 @@ function getGmail2GDriveConfig() {
         "filter": "has:attachment from:example4@example.com",
         "folder": "'Examples/example4'",
         "filenameFrom": "file.txt",
-        "filenameTo": "'file-'yyyy-MM-dd-'%s.txt'"
+        "filenameTo": "'file-'yyyy-MM-dd-'#SUBJECT#.txt'"
       }
     ]
   };

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Gmail2GDrive
 ============
 
-Gmail2GDrive is a Google Apps Script which automatically stores and sorts Gmail attachments into Google Drive folders, and can also save the thread as a PDF file.
+Gmail2GDrive is a [Google Apps Script](https://developers.google.com/apps-script/) which automatically saves Gmail attachments into Google Drive folders, and can also save the thread as a PDF file.
 
 It does so by defining a list of rules which consist of Gmail search filters and Google Drive destination folders.
 This way the attachments of periodic emails can be automatically organized in folders without the need to install and run anything on the client.
@@ -26,7 +26,7 @@ Setup
 4. Replace the content of the created file Code.gs with the provided [Code.gs](https://github.com/ahochsteger/gmail2gdrive/blob/master/Code.gs) and save the changes.
 5. Create a new script file with the name 'Config' and replace its content with the provided [Config.gs](https://github.com/ahochsteger/gmail2gdrive/blob/master/Config.gs) and save the changes.
 6. Adjust the configuration to your needs. It is recommended to restrict the timeframe using 'newerThan' to prevent running into API quotas by Google.
-7. Test the script by manually executing the function performGmail2GDrive.
+7. Test the script by manually executing the function perform `Gmail2GDrive`.
 8. Create a time based trigger which periodically executes 'Gmail2GDrive' (e.g. once per day) to automatically organize your Gmail attachments within Google Drive.
 
 
@@ -60,8 +60,11 @@ A rule supports the following parameters documentation:
 * filenameFrom (String, optional): The attachment filename that should be renamed when stored in Google Drive
 * filenameFromRegexp (String, optional): A regular expression to specify only relevant attachments
 * filenameTo (String, optional): The pattern for the new filename of the attachment. If 'filenameFrom' is not given then this will be the new filename for all attachments.
-  * You can use '%s' to insert the email subject and date format patterns like 'yyyy' for year, 'MM' for month and 'dd' for day as pattern in the filename.
+  * You can use the placeholder '#SUBJECT#' to insert the email subject into the new filename
+  * You can use the placeholder '#FILE#' to insert the original attachment's filename into the new filename
+  * you can use date format patterns like 'yyyy' for year, 'MM' for month and 'dd' for day as pattern in the filename.
   * See https://developers.google.com/apps-script/reference/utilities/utilities#formatDate(Date,String,String) for more information on the possible date format strings.
+  * Example: "yyyy-MM-dd' #FILE#'" adds today's date before the original filename 
 * saveThreadPDF (boolean, optional): Should the thread be saved as a PDF? (default: false)
 
 
@@ -107,7 +110,7 @@ function getGmail2GDriveConfig() {
         // defined in 'filenameTo' and archive the thread.
         "filter": "(from:example3a@example.com OR from:example3b@example.com)",
         "folder": "'Examples/example3ab'",
-        "filenameTo": "'file-'yyyy-MM-dd-'%s.txt'",
+        "filenameTo": "'file-'yyyy-MM-dd-'#FILE#'",
         "archive": true
       },
       {
@@ -122,7 +125,7 @@ function getGmail2GDriveConfig() {
         "filter": "from:example4@example.com",
         "folder": "'Examples/example4'",
         "filenameFrom": "file.txt",
-        "filenameTo": "'file-'yyyy-MM-dd-'%s.txt'"
+        "filenameTo": "'file-'yyyy-MM-dd-'#SUBJECT#.txt'"
       }
     ]
   };
@@ -130,10 +133,10 @@ function getGmail2GDriveConfig() {
 ```
 
 
-Feedback and contributions
+Feedback and Contributions
 --------------------------
 
-Feedback and contributions is well appreciated via [Github](https://github.com/ahochsteger/gmail2gdrive).
+Feedback and contributions are well appreciated via [Github](https://github.com/ahochsteger/gmail2gdrive).
 
 
 Thanks

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ Global Configuration
 --------------------
 
 * globalFilter: Global filter expression (see https://support.google.com/mail/answer/7190?hl=en for avialable search operators)
-  * Example: "globalFilter": "has:attachment -in:trash -in:drafts -in:spam"
+  * Example: `"globalFilter": "has:attachment -in:trash -in:drafts -in:spam"`
 * processedLabel: The GMail label to mark processed threads (will be created, if not existing)
   * Example: `"processedLabel": "to-gdrive/processed"`
 * sleepTime: Sleep time in milliseconds between processed messages
-  * Example: "sleepTime": 100
+  * Example: `"sleepTime": 100`
 * maxRuntime: Maximum script runtime in seconds (Google Scripts will be killed after 5 minutes)
-  * Example: "maxRuntime": 280
+  * Example: `"maxRuntime": 280`
 * newerThan: Only process message newer than (leave empty for no restriction; use d, m and y for day, month and year)
-  * Example: "newerThan": "1m"
+  * Example: `"newerThan": "1m"`
 * timezone: Timezone for date/time operations
-  * Example: "timezone": "GMT"
+  * Example: `"timezone": "GMT"`
 * rules: List of rules to be processed
-  * Example: "rules": [ {..rule1..}, {..rule2..}, ... ]
+  * Example: `"rules": [ {..rule1..}, {..rule2..}, ... ]`
 
 
 Rule Configuration
@@ -60,11 +60,11 @@ A rule supports the following parameters documentation:
 * filenameFrom (String, optional): The attachment filename that should be renamed when stored in Google Drive
 * filenameFromRegexp (String, optional): A regular expression to specify only relevant attachments
 * filenameTo (String, optional): The pattern for the new filename of the attachment. If 'filenameFrom' is not given then this will be the new filename for all attachments.
-  * You can use the placeholder '#SUBJECT#' to insert the email subject into the new filename
-  * You can use the placeholder '#FILE#' to insert the original attachment's filename into the new filename
-  * you can use date format patterns like 'yyyy' for year, 'MM' for month and 'dd' for day as pattern in the filename.
+  * You can use the placeholder `#SUBJECT#` to insert the email subject into the new filename
+  * You can use the placeholder `#FILE#` to insert the original attachment's filename into the new filename
+  * you can use date format patterns like `yyyy` for year, `MM` for month and `dd` for day as pattern in the filename.
   * See https://developers.google.com/apps-script/reference/utilities/utilities#formatDate(Date,String,String) for more information on the possible date format strings.
-  * Example: "yyyy-MM-dd' #FILE#'" adds today's date before the original filename 
+  * Example: `"yyyy-MM-dd' #FILE#'"` adds today's date before the original filename 
 * saveThreadPDF (boolean, optional): Should the thread be saved as a PDF? (default: false)
 
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Features
 Setup
 -----
 
-1. Open [Google Apps Script](https://script.google.com/).
+1. Open [Google Apps Script Dashboard](https://script.google.com/).
 2. Create an empty project.
 3. Give the project a name (e.g. MyGmail2GDrive)
-4. Replace the content of the created file Code.gs with the provided [Code.gs](https://github.com/ahochsteger/gmail2gdrive/blob/master/Code.gs) and save the changes.
-5. Create a new script file with the name 'Config' and replace its content with the provided [Config.gs](https://github.com/ahochsteger/gmail2gdrive/blob/master/Config.gs) and save the changes.
+4. Replace the content of the created file Code.gs with the provided [Code.gs](Code.gs) and save the changes.
+5. Create a new script file with the name `Config` and replace its content with the provided [Config.gs](Config.gs) and save the changes.
 6. Adjust the configuration to your needs. It is recommended to restrict the timeframe using 'newerThan' to prevent running into API quotas by Google.
 7. Test the script by manually executing the function perform `Gmail2GDrive`.
-8. Create a time based trigger which periodically executes 'Gmail2GDrive' (e.g. once per day) to automatically organize your Gmail attachments within Google Drive.
+8. Create a time based trigger which periodically executes `Gmail2GDrive` (e.g. once per day) to automatically organize your Gmail attachments within Google Drive.
 
 
 Global Configuration
@@ -36,7 +36,7 @@ Global Configuration
 * globalFilter: Global filter expression (see https://support.google.com/mail/answer/7190?hl=en for avialable search operators)
   * Example: "globalFilter": "has:attachment -in:trash -in:drafts -in:spam"
 * processedLabel: The GMail label to mark processed threads (will be created, if not existing)
-  * Example: "processedLabel": "to-gdrive/processed"
+  * Example: `"processedLabel": "to-gdrive/processed"`
 * sleepTime: Sleep time in milliseconds between processed messages
   * Example: "sleepTime": 100
 * maxRuntime: Maximum script runtime in seconds (Google Scripts will be killed after 5 minutes)


### PR DESCRIPTION
Hallo Andreas,

ich brauchte die Funktion, den originalen Dateinamen des Attachments wieder einzufügen. Dabei habe ich den Platzhalter #FILE# eingeführt und konsequenterweise auch gleich #SUBJECT# (%s wird weiterhin unterstützt). Die Fallunterscheidung für den `filenameFrom`-Filter habe ich etwas verändert. Ich hoffe, in Deinem Sinne.

Würde mich über dein Feedback freuen bzw. wenn Du den pull request akzeptieren würdest. 
Dein Skript läuft bei uns super und legt Eingangsrechnungen der Lieferanten in einen GDrive-Ordner für den Steuerberater ab. 
 
Viele Grüße aus Berlin

Arndt