### PR TITLE
Improvements to filenameTo

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -47,7 +47,7 @@ function Gmail2GDrive() {
         processMessage(message, rule, config);
       }
       if (doPDF) { // Generate a PDF document of a thread:
-        processThreadToPdf(thread, rule);
+        processThreadToPdf(thread, rule,config);
       }
 
       // Mark a thread as processed:
@@ -160,12 +160,12 @@ function processMessage(message, rule, config) {
       var file = folder.createFile(attachment);
       var filename = file.getName();
       if (rule.filenameFrom && rule.filenameTo && rule.filenameFrom == file.getName()) {
-        filename = Utilities.formatDate(messageDate, config.timezone, rule.filenameTo.replace('%s',message.getSubject()));
+        filename = Utilities.formatDate(messageDate, config.timezone, rule.filenameTo.replace('%s',message.getSubject()).replace('%o', filename));
         Logger.log("INFO:           Renaming matched file '" + file.getName() + "' -> '" + filename + "'");
         file.setName(filename);
       }
       else if (rule.filenameTo) {
-        filename = Utilities.formatDate(messageDate, config.timezone, rule.filenameTo.replace('%s',message.getSubject()));
+        filename = Utilities.formatDate(messageDate, config.timezone, rule.filenameTo.replace('%s',message.getSubject()).replace('%o', filename));
         Logger.log("INFO:           Renaming '" + file.getName() + "' -> '" + filename + "'");
         file.setName(filename);
       }
@@ -200,11 +200,20 @@ function processThreadToHtml(thread) {
 /**
 * Generate a PDF document for the whole thread using HTML from .
  */
-function processThreadToPdf(thread, rule) {
+function processThreadToPdf(thread, rule, config) {
   Logger.log("INFO: Saving PDF copy of thread '" + thread.getFirstMessageSubject() + "'");
   var folder = getOrCreateFolder(rule.folder);
   var html = processThreadToHtml(thread);
   var blob = Utilities.newBlob(html, 'text/html');
-  var pdf = folder.createFile(blob.getAs('application/pdf')).setName(thread.getFirstMessageSubject() + ".pdf");
+  var pdf;
+  if (rule.filenameTo) {
+    filename = Utilities.formatDate(thread.getMessages()[0].getDate(), config.timezone, rule.filenameTo.replace('%s',thread.getFirstMessageSubject()));
+    Logger.log("INFO:           Renaming '" + thread.getFirstMessageSubject() + "' -> '" + filename + "'");
+    pdf = folder.createFile(blob.getAs('application/pdf')).setName(filename + ".pdf");
+  } else {
+    pdf = folder.createFile(blob.getAs('application/pdf')).setName(thread.getFirstMessageSubject() + ".pdf");
+  }
+  
   return pdf;
 }
+

--- a/Config.gs
+++ b/Config.gs
@@ -34,6 +34,9 @@ function getGmail2GDriveConfig() {
       { // Store all attachments from example3a@example.com OR from:example3b@example.com
         // to the folder "Examples/example3ab" while renaming all attachments to the pattern
         // defined in 'filenameTo' and archive the thread.
+        // filenameTo supports the following printf style substitutions:
+        // %s - The subject of the message/thread
+        // %o - The original filename of the attachement
         "filter": "has:attachment (from:example3a@example.com OR from:example3b@example.com)",
         "folder": "'Examples/example3ab'",
         "filenameTo": "'file-'yyyy-MM-dd-'%s.txt'",
@@ -45,9 +48,23 @@ function getGmail2GDriveConfig() {
         "saveThreadPDF": true,
         "folder": "PDF Emails"
       },
+      {
+        // Store threads marked with label "PDF" in the folder "PDF Emails" als PDF document.
+        // while renaming the PDFs to the pattern defined in 'filenameTo'.
+        // filenameTo supports the following printf style substitutions:
+        // %s - The subject of the message/thread
+        // NOTE: .pdf will automatically be added to the file name
+        "filter": "label:PDF",
+        "saveThreadPDF": true,
+        "folder": "PDF Emails",
+        "filenameTo": "'file-'yyyy-MM-dd-'%s'"
+      },
       { // Store all attachments named "file.txt" from example4@example.com to the
         // folder "Examples/example4" and rename the attachment to the pattern
         // defined in 'filenameTo' and archive the thread.
+        // filenameTo supports the following printf style substitutions:
+        // %s - The subject of the message/thread
+        // %o - The original filename of the attachement
         "filter": "has:attachment from:example4@example.com",
         "folder": "'Examples/example4'",
         "filenameFrom": "file.txt",


### PR DESCRIPTION
* When creating  a PDF of a thread, allow filenameTo to be used to change the output filename

* Allow the use of %o in filenameTo for attachments that is substituted for the original filename